### PR TITLE
Fix MediatR handler registration

### DIFF
--- a/CoreWebApi/Program.cs
+++ b/CoreWebApi/Program.cs
@@ -32,9 +32,10 @@ builder.Services.AddSwaggerGen(c =>
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "BAS Challenge", Version = "v1" });
 });
 
-builder.Services.AddMediatR(cfg => {
-    // Registra todos los handlers de los ensamblados especificados
-    cfg.RegisterServicesFromAssembly(typeof(CreateHandler<>).Assembly);
+builder.Services.AddMediatR(cfg =>
+{
+    // Register handlers from the assembly where the generic handlers live
+    cfg.RegisterServicesFromAssemblyContaining(typeof(GetHandler<>));
 });
 
 builder.Services.AddScoped<IRepositoryFactory, RepositoryFactory>();


### PR DESCRIPTION
## Summary
- update MediatR registration to scan the assembly containing the generic handlers

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bde407a8832dbe76ec1ec19b9f8c