### PR TITLE
Externalize secrets

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+# Sample environment variables for docker-compose
+MSSQL_SA_PASSWORD=YourStrong!Passw0rd
+CONNECTIONSTRINGS__SQLSERVERCONNECTION=Server=sql_server_container;Database=BasChallenge;User Id=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ obj/
 *.dll
 *.pdb
 *.exe
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# basbackend
+
+Este proyecto incluye una solución .NET para la API `CoreWebApi` y servicios relacionados.
+
+## Variables sensibles
+
+Para evitar exponer contraseñas en el archivo `docker-compose.yml`, se utilizan variables de entorno cargadas desde un archivo `.env` (no versionado). Se provee un ejemplo en `.env.sample`.
+
+1. Copia `.env.sample` a `.env` y ajusta los valores de acuerdo a tu entorno.
+2. Ejecuta `docker compose up` normalmente; Docker Compose leerá las variables desde `.env`.
+
+```
+cp .env.sample .env
+# editar .env con tus valores
+```
+
+Estas variables se referencian en `docker-compose.yml` mediante la sintaxis `${VARIABLE}`.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: CoreWebApi/Dockerfile
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-        - ConnectionStrings__SqlServerConnection=Server=sql_server_container;Database=BasChallenge;User Id=sa;Password=BasBackend!;TrustServerCertificate=True
+      - ConnectionStrings__SqlServerConnection=${CONNECTIONSTRINGS__SQLSERVERCONNECTION}
     networks:
       - mynetwork
     ports:
@@ -21,7 +21,7 @@ services:
     image: mcr.microsoft.com/mssql/server:latest
     environment:
       - ACCEPT_EULA=Y
-      - SA_PASSWORD=BasBackend!
+      - SA_PASSWORD=${MSSQL_SA_PASSWORD}
     networks:
       - mynetwork
     ports:


### PR DESCRIPTION
## Summary
- move sensitive values from docker-compose to environment variables
- add `.env.sample` example file
- ignore `.env` by git
- document secret usage in README

## Testing
- `git status --short`
- `grep -n "Password=" -R docker-compose.yml`

------
https://chatgpt.com/codex/tasks/task_e_685814deadf0832db663a5335c5f0fea